### PR TITLE
add eventlistener to body to allow clicking anywhere to get next talk

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -52,6 +52,9 @@ export default {
           this.nextTalk();
         }
       });
+      document.body.addEventListener('click', e => {
+          this.nextTalk();
+      });
     }
   },
   data() {
@@ -71,6 +74,14 @@ export default {
   text-align: center;
   color: #2c3e50;
   margin-top: 60px;
+}
+
+html {
+  height: 100vh;
+}
+
+body {
+  height: 92%;
 }
 
 h1, h2 {

--- a/src/app.vue
+++ b/src/app.vue
@@ -73,15 +73,17 @@ export default {
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
 }
 
 html {
-  height: 100vh;
+  height: 100%;
 }
 
 body {
-  height: 92%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 h1, h2 {


### PR DESCRIPTION
#6 User can now click on the body of the page to get the next talk. Added some styling to stretch the body across the whole height of the device.